### PR TITLE
Print errors, upgrade docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM alpine:3.5
+FROM alpine:3.12
 
 RUN apk add --update-cache py3-pip ca-certificates py3-certifi py3-lxml\
                            python3-dev cython cython-dev libusb-dev build-base \
                            eudev-dev linux-headers libffi-dev openssl-dev \
                            jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev \
-                           tiff-dev tk-dev tcl-dev
+                           tiff-dev tk-dev tcl-dev tzdata
 
 COPY setup.py README.rst requirements.txt /build/
 RUN pip3 install -r /build/requirements.txt
 
 COPY aws_google_auth /build/aws_google_auth
 RUN pip3 install -e /build/[u2f]
-
+ENV TZ=Europe/Amsterdam
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["aws-google-auth"]

--- a/aws_google_auth/google.py
+++ b/aws_google_auth/google.py
@@ -80,6 +80,9 @@ class Google:
             sess.raise_for_status()
         except HTTPError as ex:
 
+            print("Error occurred:\n")
+            print(sess.text)
+
             if self.save_failure:
                 logging.exception("Saving failure trace in 'failure.html'", ex)
                 with open("failure.html", 'w') as out:
@@ -330,7 +333,8 @@ class Google:
         try:
             saml_element = parsed.find('input', {'name': 'SAMLResponse'}).get('value')
         except:
-
+            print("Error ocurred:\n")
+            print(str(self.session_state.text.encode('utf-8')))
             if self.save_failure:
                 logging.error("SAML lookup failed, storing failure page to "
                               "'saml.html' to assist with debugging.")


### PR DESCRIPTION
This PR prints errors instead of saving them to a file. The saving to file option is a bit annoying when using docker.

This can be tested with the following docker image:
```
quay.io/lunarway/aws-google-auth:0.0.36-print
```